### PR TITLE
fix: 'generator' object is not subscriptable error and add custom role names dict

### DIFF
--- a/llama_cpp_guidance/llm.py
+++ b/llama_cpp_guidance/llm.py
@@ -50,8 +50,8 @@ class LlamaCpp(LLM):
         role_end_tag="<|im_end|>",
         chat_mode=False,
         seed: int = 0,
-        role_to_name: Dict[str, str],
-        **llama_kwargs: Dict[str, Any]
+        role_to_name: Dict[str, str] = {},
+        **llama_kwargs: Dict[str, Any] = {}
     ):
         super().__init__()
         self.llm_name = "llama-cpp"

--- a/llama_cpp_guidance/llm.py
+++ b/llama_cpp_guidance/llm.py
@@ -86,8 +86,13 @@ class LlamaCpp(LLM):
             raise NotImplementedError
 
     def __call__(self, *args, **kwargs):
-        logger.debug("Invoking LlamaCpp ({args}) ({kwargs})", args=args, kwargs=kwargs)
-        for output in self.llm(*args, **kwargs):
+        print("Invoking LlamaCpp ({args}) ({kwargs})", args, kwargs)
+
+        llm_out = self.llm(*args, **kwargs)
+        if isinstance(llm_out, dict):
+            llm_out = [llm_out]
+        
+        for output in llm_out:
             logger.debug(
                 "LlamaCpp generated text: {text} ({choices})",
                 text=output["choices"][0]["text"],

--- a/llama_cpp_guidance/llm.py
+++ b/llama_cpp_guidance/llm.py
@@ -72,6 +72,7 @@ class LlamaCpp(LLM):
             logits_all=True,
             verbose=False,
             seed=seed,
+            **llama_kwargs
         )
         logger.debug("Llama instantiated")
         self._tokenizer = LlamaCppTokenizer(self.llm)

--- a/llama_cpp_guidance/llm.py
+++ b/llama_cpp_guidance/llm.py
@@ -1,7 +1,7 @@
 import os
 from pathlib import Path
 
-from typing import Dict, List, Literal, Optional, Union
+from typing import Dict, List, Literal, Optional, Union, Any
 from guidance.llms import LLM, LLMSession
 
 from llama_cpp import Llama, StoppingCriteriaList
@@ -50,6 +50,8 @@ class LlamaCpp(LLM):
         role_end_tag="<|im_end|>",
         chat_mode=False,
         seed: int = 0,
+        role_to_name: Dict[str, str],
+        **llama_kwargs: Dict[str, Any]
     ):
         super().__init__()
         self.llm_name = "llama-cpp"
@@ -83,41 +85,41 @@ class LlamaCpp(LLM):
 
     def __call__(self, *args, **kwargs):
         logger.debug("Invoking LlamaCpp ({args}) ({kwargs})", args=args, kwargs=kwargs)
-        output = self.llm(*args, **kwargs)
-        logger.debug(
-            "LlamaCpp generated text: {text} ({choices})",
-            text=output["choices"][0]["text"],
-            choices=[
-                (choice["text"], choice["logprobs"]) for choice in output["choices"]
-            ],
-        )
-
-        for choice in output.get("choices", []):
-            logprobs = choice.get("logprobs")
-
-            if not logprobs:
-                continue
-
-            new_top_logprobs = []
-            for index, top_logprobs in enumerate(logprobs["top_logprobs"]):
-                if top_logprobs is None:
-                    top_logprobs = {choice["logprobs"]["tokens"][index]: -0.1}
-
-                new_top_logprobs.append(top_logprobs)
-            logprobs["top_logprobs"] = new_top_logprobs
-
-        return output
+        for output in self.llm(*args, **kwargs):
+            logger.debug(
+                "LlamaCpp generated text: {text} ({choices})",
+                text=output["choices"][0]["text"],
+                choices=[
+                    (choice["text"], choice["logprobs"]) for choice in output["choices"]
+                ],
+            )
+    
+            for choice in output.get("choices", []):
+                logprobs = choice.get("logprobs")
+    
+                if not logprobs:
+                    continue
+    
+                new_top_logprobs = []
+                for index, top_logprobs in enumerate(logprobs["top_logprobs"]):
+                    if top_logprobs is None:
+                        top_logprobs = {choice["logprobs"]["tokens"][index]: -0.1}
+    
+                    new_top_logprobs.append(top_logprobs)
+                logprobs["top_logprobs"] = new_top_logprobs
+    
+            yield output
 
     def token_to_id(self, text):
         ids = self.encode(text, add_bos=False)
 
         return ids[-1]
-
+    
     def role_start(self, role_name, **kwargs):
         assert self.chat_mode, "role_start() can only be used in chat mode"
         return (
             self.role_start_tag
-            + role_name
+            + self.role_to_name.get(role_name, role_name)
             + "".join([f' {k}="{v}"' for k, v in kwargs.items()])
             + "\n"
         )

--- a/llama_cpp_guidance/llm.py
+++ b/llama_cpp_guidance/llm.py
@@ -60,6 +60,7 @@ class LlamaCpp(LLM):
         self.role_start_tag = role_start_tag
         self.role_end_tag = role_end_tag
         self.chat_mode = chat_mode
+        self.role_to_name = role_to_name
 
         logger.debug(f"Instantiating LlamaCpp ({model_path})")
 

--- a/llama_cpp_guidance/llm.py
+++ b/llama_cpp_guidance/llm.py
@@ -94,28 +94,27 @@ class LlamaCpp(LLM):
                     (choice["text"], choice["logprobs"]) for choice in output["choices"]
                 ],
             )
-    
+
             for choice in output.get("choices", []):
                 logprobs = choice.get("logprobs")
-    
+
                 if not logprobs:
                     continue
-    
+
                 new_top_logprobs = []
                 for index, top_logprobs in enumerate(logprobs["top_logprobs"]):
                     if top_logprobs is None:
                         top_logprobs = {choice["logprobs"]["tokens"][index]: -0.1}
-    
+
                     new_top_logprobs.append(top_logprobs)
                 logprobs["top_logprobs"] = new_top_logprobs
-    
+
             yield output
 
     def token_to_id(self, text):
         ids = self.encode(text, add_bos=False)
 
         return ids[-1]
-    
     def role_start(self, role_name, **kwargs):
         assert self.chat_mode, "role_start() can only be used in chat mode"
         return (

--- a/llama_cpp_guidance/llm.py
+++ b/llama_cpp_guidance/llm.py
@@ -86,7 +86,7 @@ class LlamaCpp(LLM):
             raise NotImplementedError
 
     def __call__(self, *args, **kwargs):
-        print("Invoking LlamaCpp ({args}) ({kwargs})", args, kwargs)
+        logger.debug("Invoking LlamaCpp ({args}) ({kwargs})", args, kwargs)
 
         llm_out = self.llm(*args, **kwargs)
         if isinstance(llm_out, dict):

--- a/llama_cpp_guidance/llm.py
+++ b/llama_cpp_guidance/llm.py
@@ -51,7 +51,7 @@ class LlamaCpp(LLM):
         chat_mode=False,
         seed: int = 0,
         role_to_name: Dict[str, str] = {},
-        **llama_kwargs: Dict[str, Any] = {}
+        **llama_kwargs: Dict[str, Any]
     ):
         super().__init__()
         self.llm_name = "llama-cpp"


### PR DESCRIPTION
- Fixes https://github.com/nicholasyager/llama-cpp-guidance/issues/1
- Adds `role_to_name` argument
- Adds `llama_kwargs` to pass arbitrary kwargs to LlamaCpp

Example Usage:
```python
from pathlib import Path
import pathlib
from typing import Optional
from llama_cpp_guidance.llm import LlamaCpp
from huggingface_hub import hf_hub_download
import os
os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = "1"

REPO_ID = "TheBloke/Phind-CodeLlama-34B-v2-GGUF"

download_filename = hf_hub_download(repo_id=REPO_ID, filename="phind-codellama-34b-v2.Q3_K_M.gguf")
import guidance


guidance.llm = LlamaCpp(
    model_path=Path(download_filename),
    n_gpu_layers=-1,
    n_threads=4,
    n_ctx=4096,
    role_start_tag="### ",
    role_end_tag="",
    chat_mode=True,
    role_to_name={"assistant": "Assistant", "user": "User Message", "system": "System Prompt"}
)

experts = guidance('''{{#system}}You are a helpful and terse assistant.{{/system}}

{{#user}}I want a response to the following question:
{{query}}
Name 3 world-class experts (past or present) who would be great at answering this?
Don't answer the question yet.{{/user}}

{{#assistant}}{{~gen 'expert_names' temperature=0 max_tokens=300 stop=["\n###"]}}{{/assistant}}

{{#user}}Great, now please answer the question as if these experts had collaborated in writing a joint anonymous answer.{{/user}}

{{#assistant}}{{~gen 'answer' temperature=0 max_tokens=500 stop=["\n###"]}}{{/assistant}}''')

output = experts(query='How can I be more productive?')
print(output)
```

